### PR TITLE
Fix PyPI Publishing Workflow for Releases and Tags

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -103,11 +103,15 @@ jobs:
             
             throw new Error('Timeout waiting for tests to complete after 5 minutes');
 
-  # Run tests for PRs only
+  # Run tests for PRs, releases, and version tags
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'release' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      github.event_name == 'workflow_dispatch'
     
     steps:
     - uses: actions/checkout@v4
@@ -148,6 +152,8 @@ jobs:
       always() && 
       !contains(needs.*.result, 'failure') && 
       !contains(needs.*.result, 'cancelled') &&
+      (needs.test.result == 'success' || needs.test.result == 'skipped') &&
+      (needs.check-tests.result == 'success' || needs.check-tests.result == 'skipped') &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
 
     steps:


### PR DESCRIPTION
## 🐛 Problem

The PyPI publishing workflow was not triggering correctly when creating GitHub releases or pushing version tags. The issue was caused by conditional job dependencies that prevented the workflow from executing properly for release events.

### Root Cause Analysis

1. The `test` job only ran for pull requests (`if: github.event_name == 'pull_request'`)
2. The `check-tests` job only ran for pushes to the develop branch
3. When creating a release or pushing a tag, neither job would execute
4. The `build` job depended on both jobs, causing the dependency chain to break
5. The `publish-to-pypi` job couldn't run without a successful `build` job

## ✅ Solution

Updated the workflow to ensure tests run for all publishing scenarios while maintaining quality checks.

### Changes Made

#### 1. Extended Test Job Triggers (`test` job - line 110-114)
**Before:**
```yaml
if: github.event_name == 'pull_request'
```

**After:**
```yaml
if: |
  github.event_name == 'pull_request' ||
  github.event_name == 'release' ||
  startsWith(github.ref, 'refs/tags/v') ||
  github.event_name == 'workflow_dispatch'
```

#### 2. Improved Build Job Conditions (`build` job - line 151-157)
**Before:**
```yaml
if: |
  always() && 
  !contains(needs.*.result, 'failure') && 
  !contains(needs.*.result, 'cancelled') &&
  (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
```

**After:**
```yaml
if: |
  always() && 
  !contains(needs.*.result, 'failure') && 
  !contains(needs.*.result, 'cancelled') &&
  (needs.test.result == 'success' || needs.test.result == 'skipped') &&
  (needs.check-tests.result == 'success' || needs.check-tests.result == 'skipped') &&
  (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
```

## 🎯 Impact

- **Tests now run for releases and tags** - Ensures code quality before publishing
- **Dependency chain works correctly** - Build job handles conditional dependencies properly
- **PyPI publishing will trigger** - Releases and version tags will successfully publish to PyPI
- **Backward compatible** - Existing PR and develop branch workflows remain unchanged

## 🧪 Testing

After merging this PR, the workflow will correctly:

1. Run tests when a release is created
2. Run tests when a version tag (v*) is pushed
3. Build the distribution packages after tests pass
4. Publish to PyPI for releases and version tags
5. Continue to publish to TestPyPI for develop branch and PRs

## 📝 Next Steps

1. Merge this PR to master
2. Either:
   - Re-trigger the v0.1.0 release workflow, or
   - Create a new patch release (v0.1.1) to test the fixed workflow

## ✔️ Checklist

- [x] Workflow syntax is valid
- [x] Tests run for all publishing scenarios
- [x] Quality checks are maintained